### PR TITLE
switch to community ART implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules"
     ]
+  },
+  "dependencies": {
+    "@react-native-community/art": "^1.1.2"
   }
 }

--- a/src/ART.js
+++ b/src/ART.js
@@ -1,0 +1,3 @@
+import * as ART from '@react-native-community/art'
+
+export default ART

--- a/src/Band.js
+++ b/src/Band.js
@@ -3,7 +3,8 @@
  */
 
 import * as React from 'react'
-import { ART } from 'react-native'
+import ART from './ART'
+
 import { makeRect } from './shape'
 import * as helper from './helper'
 import * as typed from './typed'

--- a/src/Fill.js
+++ b/src/Fill.js
@@ -3,7 +3,8 @@
  */
 
 import * as React from 'react'
-import { ART } from 'react-native'
+import ART from './ART'
+
 import { makeLine } from './shape'
 import * as typed from './typed'
 

--- a/src/Guide.js
+++ b/src/Guide.js
@@ -3,7 +3,8 @@
  */
 
 import * as React from 'react'
-import { ART } from 'react-native'
+import ART from './ART'
+
 import * as helper from './helper'
 import * as typed from './typed'
 

--- a/src/Line.js
+++ b/src/Line.js
@@ -3,7 +3,8 @@
  */
 
 import * as React from 'react'
-import { ART } from 'react-native'
+import ART from './ART'
+
 import { makeLine } from './shape'
 import * as typed from './typed'
 

--- a/src/Sparkline.js
+++ b/src/Sparkline.js
@@ -3,7 +3,8 @@
  */
 
 import * as React from 'react'
-import { ART } from 'react-native'
+import ART from './ART'
+
 import createScale from './scale'
 import * as helper from './helper'
 import * as typed from './typed'

--- a/src/Spots.js
+++ b/src/Spots.js
@@ -3,7 +3,8 @@
  */
 
 import * as React from 'react'
-import { ART } from 'react-native'
+import ART from './ART'
+
 import { makeCircle } from './shape'
 import * as helper from './helper'
 import * as typed from './typed'

--- a/src/shape.js
+++ b/src/shape.js
@@ -2,7 +2,8 @@
  * @flow
  */
 
-import { ART } from 'react-native'
+import ART from './ART'
+
 import * as typed from './typed'
 
 type CircleProps = {


### PR DESCRIPTION
ART was extracted from core `react-native` and moved to `@react-native-community/art`. These are the following changes are required in the library. 